### PR TITLE
chore: Check the received XState config

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,1 +1,10 @@
-{"api":"1.0.0","editorType":["figma"],"id":"figma-to-xstate","name":"Figma to XState","main":"build/main.js","ui":"build/ui.js"}
+{
+  "api": "1.0.0",
+  "editorType": [
+    "figma"
+  ],
+  "id": "figma-to-xstate",
+  "name": "Figma to XState",
+  "main": "build/main.js",
+  "ui": "build/ui.js"
+}

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "dependencies": {
     "@create-figma-plugin/utilities": "2.6.1",
     "code-block-writer": "12.0.0",
-    "figx": "^0.1.3"
+    "figx": "0.1.3"
   },
   "devDependencies": {
     "@create-figma-plugin/build": "2.6.1",
     "@create-figma-plugin/tsconfig": "2.6.1",
-    "@create-figma-plugin/ui": "^3.0.2",
+    "@create-figma-plugin/ui": "3.0.2",
     "@figma/plugin-typings": "1.79.0",
-    "preact": "^10.18.1",
+    "preact": "10.18.1",
     "typescript": "5.2.2",
     "vitest": "0.34.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ dependencies:
     specifier: 12.0.0
     version: 12.0.0
   figx:
-    specifier: ^0.1.3
+    specifier: 0.1.3
     version: 0.1.3
 
 devDependencies:
@@ -23,13 +23,13 @@ devDependencies:
     specifier: 2.6.1
     version: 2.6.1
   '@create-figma-plugin/ui':
-    specifier: ^3.0.2
+    specifier: 3.0.2
     version: 3.0.2(preact@10.18.1)
   '@figma/plugin-typings':
     specifier: 1.79.0
     version: 1.79.0
   preact:
-    specifier: ^10.18.1
+    specifier: 10.18.1
     version: 10.18.1
   typescript:
     specifier: 5.2.2

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 import { type FigmaAgnosticDescriptor } from './types'
 import { type GeneratorOptions, createXStateV4Machine } from './generators'
-import { copyToClipboard } from 'figx'
 import { traversePage } from './traverse'
 import { generateNewWriter } from './utils'
 import { showUI } from '@create-figma-plugin/utilities'
@@ -31,9 +30,9 @@ export default function main() {
   createXStateV4Machine(generatorOptions)
   // --------------------------------------------------
 
-  const content = writer.toString()
+  const generatedXStateConfig = writer.toString()
   const options = { width: 480, height: 240 }
-  showUI(options, { content })
+  showUI(options, { generatedXStateConfig })
 
   // Make sure to close the plugin when you're done. Otherwise the plugin will
   // keep running, which shows the cancel button at the bottom of the screen.

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,27 +1,53 @@
-import {
-  Container,
-  render,
-  Text,
-  VerticalSpace,Code,Space
-} from "@create-figma-plugin/ui";
-import { h } from "preact";
-import { useEffect } from "preact/hooks";
-import {copyToClipboard} from 'figx'
+import { h } from 'preact'
+import { useEffect } from 'preact/hooks'
+import { copyToClipboard } from 'figx'
 
-function UI({ content }: { content: string} ) {
+import {
+  Code,
+  Text,
+  Banner,
+  render,
+  Container,
+  IconWarning32,
+  VerticalSpace,
+} from '@create-figma-plugin/ui'
+
+function SomethingWentWrong({ reason }: { reason: string }) {
+  return (
+    <Banner icon={<IconWarning32 />} variant="warning">
+      Something went wrong ({reason})
+    </Banner>
+  )
+}
+
+function PrintXStateV4Config({ generatedXStateConfig }: { generatedXStateConfig: string }) {
   useEffect(() => {
-    copyToClipboard(content)
-  }, [content])
+    copyToClipboard(generatedXStateConfig)
+  }, [generatedXStateConfig])
 
   return (
     <Container space="medium">
       <VerticalSpace space="medium" />
-        <Text>The XState V4 config has been copied to clipboard.</Text>
+      <Text>The XState V4 config has been copied to clipboard.</Text>
       <VerticalSpace space="medium" />
-        <Code>{content}</Code>
+      <Text>
+        <Code>{generatedXStateConfig}</Code>
+      </Text>
       <VerticalSpace space="medium" />
     </Container>
-  );
+  )
 }
 
-export default render(UI);
+/**
+ * The UI entry point rendered by create-figma-plugin
+ */
+function UI({ generatedXStateConfig }: { generatedXStateConfig: unknown }) {
+  if (typeof generatedXStateConfig !== 'string') {
+    console.log({ generatedXStateConfig })
+    return <SomethingWentWrong reason="The received generatedXStateConfig is not a string" />
+  }
+
+  return <PrintXStateV4Config generatedXStateConfig={generatedXStateConfig} />
+}
+
+export default render(UI)


### PR DESCRIPTION
Despite create-figma-plugin guarantees it passes a string to the UI component, there is no way to get it inferred and so leverage a true TS protection. That's why I check it and show an error in case it is not (so the users could open an issue with the specific error).

![SCR-20231103-k8b](https://github.com/NoriSte/figma-to-xstate/assets/173663/7e836011-efbb-4044-a6a2-08c414d0c201)

The next step is to find out if I can create a link that allows the users to directly open a new issue with some prepopulated data so I could add an "open an issue" button.